### PR TITLE
Fixed success responses to improve consistency

### DIFF
--- a/src/main/routes/actor.resource.js
+++ b/src/main/routes/actor.resource.js
@@ -3,8 +3,8 @@ import { VerifierInterface } from '../api-utilities/VerifierInterface';
 import { ScenarioHandler } from '../api-utilities/ScenarioHandler';
 const router = express.Router();
 
-export default function(QueryHandler) {
-    router.put('/', async(req, res) => {
+export default function (QueryHandler) {
+    router.put('/', async (req, res) => {
         var response = {};
         try {
             var scenario = {};
@@ -25,14 +25,16 @@ export default function(QueryHandler) {
                 } else {
                     id = await QueryHandler.add(handler.scenario);
                 }
-                response = { code: 202, id: id, scenario: handler.scenario };
-
+                response = {
+                    code: 200,
+                    actor: req.body.name,
+                    scenario: id,
+                };
             } else {
                 response = { code: 400, error: verifier.check(actor) };
             }
-
         } catch {
-            response = {code: 400, error: 'Could not reach any scenario'};
+            response = { code: 400, error: 'Could not reach any scenario' };
         } finally {
             res.send(response);
         }

--- a/src/main/routes/weapon.resource.js
+++ b/src/main/routes/weapon.resource.js
@@ -3,8 +3,8 @@ import { VerifierInterface } from '../api-utilities/VerifierInterface';
 import { ScenarioHandler } from '../api-utilities/ScenarioHandler';
 const router = express.Router();
 
-export default function(QueryHandler) {
-    router.patch('/', async(req, res) => {
+export default function (QueryHandler) {
+    router.patch('/', async (req, res) => {
         var response = {};
         try {
             const idScenario = req.body.scenario;
@@ -19,13 +19,16 @@ export default function(QueryHandler) {
                 delete weapon.actor;
                 handler.replaceWeapon(weapon, actor);
                 await QueryHandler.set(idScenario, handler.scenario);
-                response = { code: 202, scenario: handler.scenario };
+                response = {
+                    code: 200,
+                    weapon: req.body.name,
+                    scenario: idScenario,
+                };
             } else {
                 response = { code: 400, error: verifier.check(weapon) };
             }
-
         } catch {
-            response = { code: 400, error: 'Could not reach the scenario'};
+            response = { code: 400, error: 'Could not reach the scenario' };
         } finally {
             res.send(response);
         }


### PR DESCRIPTION
We decided to give a format to the success responses so it kept consistent
So the response now has this structure:

```
{
                    code: 200,
                    <resource>: <resource name>
                    scenario: <idScenario>,
}
```